### PR TITLE
Fix broken examples, remove use of RetryPolicy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ hyper = "0.12.27"
 tokio = "0.1.19"
 tower = { git = "https://github.com/tower-rs/tower" }
 tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
+tower-reconnect = { git = "https://github.com/tower-rs/tower" }

--- a/src/http-client.rs
+++ b/src/http-client.rs
@@ -4,12 +4,9 @@ use hyper::{
     Request, Response, Uri,
 };
 use std::time::Duration;
-use tower::{builder::ServiceBuilder, reconnect::Reconnect, Service, ServiceExt};
-use tower_hyper::{
-    client::{Builder, Connect},
-    retry::{Body, RetryPolicy},
-    util::Connector,
-};
+use tower::{builder::ServiceBuilder, Service, ServiceExt};
+use tower_hyper::{client::Connect, util::Connector, Body};
+use tower_reconnect::Reconnect;
 
 fn main() {
     let fut = futures::lazy(|| {
@@ -22,25 +19,20 @@ fn main() {
 
 fn request() -> impl Future<Item = Response<hyper::Body>, Error = ()> {
     let connector = Connector::new(HttpConnector::new(1));
-    let hyper = Connect::new(connector, Builder::new());
+    let hyper = Connect::new(connector);
 
-    // RetryPolicy is a very simple policy that retries `n` times
-    // if the response has a 500 status code. Here, `n` is 5.
-    let policy = RetryPolicy::new(5);
     // We're calling the tower/examples/server.rs.
     let dst = Destination::try_from_uri(Uri::from_static("http://127.0.0.1:3000")).unwrap();
 
     // Now, to build the service! We use two BufferLayers in order to:
     // - provide backpressure for the RateLimitLayer, and ConcurrencyLimitLayer
-    // - meet `RetryLayer`'s requirement that our service implement `Service + Clone`
     // - ..and to provide cheap clones on the service.
     let maker = ServiceBuilder::new()
         .buffer(5)
         .rate_limit(5, Duration::from_secs(1))
         .concurrency_limit(5)
-        .retry(policy)
         .buffer(5)
-        .make_service(hyper);
+        .service(hyper);
 
     // `Reconnect` accepts a destination and a MakeService, creating a new service
     // any time the connection encounters an error.
@@ -57,7 +49,7 @@ fn request() -> impl Future<Item = Response<hyper::Body>, Error = ()> {
         .map_err(|e| panic!("Service is not ready: {:?}", e))
         .and_then(|mut c| {
             c.call(request)
-                .map(|res| res.map(|b| b.into_inner()))
+                // .map(|res| res.map(|b| b.into_inner()))
                 .map_err(|e| panic!("{:?}", e))
         })
 }

--- a/src/http-client.rs
+++ b/src/http-client.rs
@@ -47,9 +47,5 @@ fn request() -> impl Future<Item = Response<hyper::Body>, Error = ()> {
     client
         .ready()
         .map_err(|e| panic!("Service is not ready: {:?}", e))
-        .and_then(|mut c| {
-            c.call(request)
-                // .map(|res| res.map(|b| b.into_inner()))
-                .map_err(|e| panic!("{:?}", e))
-        })
+        .and_then(|mut c| c.call(request).map_err(|e| panic!("{:?}", e)))
 }

--- a/src/http-client.rs
+++ b/src/http-client.rs
@@ -27,16 +27,16 @@ fn request() -> impl Future<Item = Response<hyper::Body>, Error = ()> {
     // Now, to build the service! We use two BufferLayers in order to:
     // - provide backpressure for the RateLimitLayer, and ConcurrencyLimitLayer
     // - ..and to provide cheap clones on the service.
-    let maker = ServiceBuilder::new()
+    let service = ServiceBuilder::new()
         .buffer(5)
         .rate_limit(5, Duration::from_secs(1))
         .concurrency_limit(5)
         .buffer(5)
         .service(hyper);
 
-    // `Reconnect` accepts a destination and a MakeService, creating a new service
+    // `Reconnect` accepts a destination and a Service, creating a new service
     // any time the connection encounters an error.
-    let client = Reconnect::new(maker, dst);
+    let client = Reconnect::new(service, dst);
 
     let request = Request::builder()
         .method("GET")

--- a/src/http-server.rs
+++ b/src/http-server.rs
@@ -35,7 +35,7 @@ fn main() {
 
 struct Svc;
 impl Service<Request<Body>> for Svc {
-    type Response = Response<&'static str>;
+    type Response = Response<Body>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
 
@@ -44,7 +44,7 @@ impl Service<Request<Body>> for Svc {
     }
 
     fn call(&mut self, _req: Request<Body>) -> Self::Future {
-        let res = Response::new("Hello World!");
+        let res = Response::new(Body::from("Hello World!"));
         future::ok(res)
     }
 }

--- a/src/http-server.rs
+++ b/src/http-server.rs
@@ -2,7 +2,7 @@ use futures::{future, Future, Poll, Stream};
 use hyper::{self, Body, Request, Response};
 use tokio::net::TcpListener;
 use tower::{builder::ServiceBuilder, Service};
-use tower_hyper::{body::LiftBody, server::Server};
+use tower_hyper::server::Server;
 
 fn main() {
     hyper::rt::run(future::lazy(|| {
@@ -11,10 +11,7 @@ fn main() {
 
         println!("Listening on http://{}", addr);
 
-        let maker = ServiceBuilder::new()
-            .concurrency_limit(5)
-            .make_service(MakeSvc);
-
+        let maker = ServiceBuilder::new().concurrency_limit(5).service(MakeSvc);
         let server = Server::new(maker);
 
         bind.incoming()
@@ -37,7 +34,7 @@ fn main() {
 }
 
 struct Svc;
-impl Service<Request<LiftBody<Body>>> for Svc {
+impl Service<Request<Body>> for Svc {
     type Response = Response<&'static str>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
@@ -46,7 +43,7 @@ impl Service<Request<LiftBody<Body>>> for Svc {
         Ok(().into())
     }
 
-    fn call(&mut self, _req: Request<LiftBody<Body>>) -> Self::Future {
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
         let res = Response::new("Hello World!");
         future::ok(res)
     }


### PR DESCRIPTION
### Added

* Add dependency on `tower-reconnect`, as it is not re-exported by the main `tower` crate.

### Changed

* Return `Response<Body>` from server instead of `Response<&'static str>`.

### Removed

* Remove use of `RetryPolicy`, as it no longer exists in `tower-hyper`.
* Remove unnecessary use of `LiftBody` in `http-client.rs`.
* Remove outdated reference to `MakeService` in `http-client.rs`.

### Fixed

* Replace outdated use of `ServiceBuilder::make_service()` with `ServiceBuilder::service()`.

Closes tower-rs/tower#271.

CC @rtyler @carllerche